### PR TITLE
Add capability context and guard usage to Home tab

### DIFF
--- a/src/components/home/Guard.js
+++ b/src/components/home/Guard.js
@@ -1,0 +1,36 @@
+import React from "react";
+import { useUserContext } from "./UserContext";
+
+const Guard = ({ can, fallback = null, children }) => {
+  const { hasCapability } = useUserContext();
+
+  const requirements = React.useMemo(() => {
+    if (!can) {
+      return [];
+    }
+    return Array.isArray(can) ? can.filter(Boolean) : [can];
+  }, [can]);
+
+  const isAllowed = React.useMemo(() => {
+    if (requirements.length === 0) {
+      return true;
+    }
+    return requirements.every((capability) => hasCapability(capability));
+  }, [requirements, hasCapability]);
+
+  if (typeof children === "function") {
+    return <>{children({ isAllowed })}</>;
+  }
+
+  if (isAllowed) {
+    return <>{children}</>;
+  }
+
+  if (typeof fallback === "function") {
+    return <>{fallback({ isAllowed })}</>;
+  }
+
+  return <>{fallback}</>;
+};
+
+export default Guard;

--- a/src/components/home/Home.test.js
+++ b/src/components/home/Home.test.js
@@ -5,6 +5,11 @@ import Home from "./Home";
 import { AccountLifecycleContext } from "../../context/AccountLifecycleContext";
 import { ACCOUNT_DEACTIVATED_MESSAGE } from "../../utils/accountLifecycle";
 
+jest.mock("../../services/api", () => ({
+  get: jest.fn(),
+  post: jest.fn(),
+}));
+
 jest.mock("../../i18n", () => ({
   useTranslation: () => ({
     t: (key, options) => options?.defaultValue ?? key,
@@ -36,5 +41,8 @@ describe("Home discovery gating", () => {
 
     expect(screen.getByText(ACCOUNT_DEACTIVATED_MESSAGE)).toBeInTheDocument();
     expect(screen.queryByText("home.headers.activeUsers")).not.toBeInTheDocument();
+    expect(
+      screen.getByText("Active user discovery is not available for your account.")
+    ).toBeInTheDocument();
   });
 });

--- a/src/components/home/UserContext.js
+++ b/src/components/home/UserContext.js
@@ -1,0 +1,115 @@
+import React, { createContext, useCallback, useContext, useEffect, useMemo, useState } from "react";
+import {
+  ACCOUNT_STATUS,
+  BILLING_STATUS,
+  defaultUserSnapshot,
+  normalizeSnapshotPayload,
+} from "../../utils/userDimensions";
+import { CAPABILITIES } from "../../utils/capabilities";
+
+const defaultSnapshot = normalizeSnapshotPayload(defaultUserSnapshot());
+
+const deriveCapabilities = (snapshot) => {
+  const capabilitySet = new Set();
+
+  capabilitySet.add(CAPABILITIES.DISCOVERY_VIEW_HOME);
+
+  const isAccountDeactivated = snapshot.account === ACCOUNT_STATUS.DEACTIVATED;
+  const isAccountSuspended = snapshot.account === ACCOUNT_STATUS.SUSPENDED;
+  const isDiscoveryAllowed = !isAccountDeactivated && !isAccountSuspended;
+
+  if (isDiscoveryAllowed) {
+    [
+      CAPABILITIES.DISCOVERY_VIEW_ACTIVE_USERS,
+      CAPABILITIES.DISCOVERY_USE_FILTERS,
+      CAPABILITIES.DISCOVERY_TOGGLE_FILTER_PANEL,
+      CAPABILITIES.DISCOVERY_EXPAND_USER_PREVIEW,
+      CAPABILITIES.DISCOVERY_NAVIGATE_TO_PROFILE,
+      CAPABILITIES.DISCOVERY_COMPOSE_REQUEST,
+      CAPABILITIES.DISCOVERY_SEND_REQUEST,
+    ].forEach((capability) => capabilitySet.add(capability));
+  }
+
+  const canViewMatches =
+    isDiscoveryAllowed &&
+    snapshot.billing !== BILLING_STATUS.CANCELLED &&
+    snapshot.billing !== BILLING_STATUS.PAST_DUE;
+
+  if (canViewMatches) {
+    [
+      CAPABILITIES.MATCHES_VIEW_RECOMMENDATIONS,
+      CAPABILITIES.MATCHES_VIEW_DETAILS,
+      CAPABILITIES.MATCHES_VIEW_COMPATIBILITY,
+      CAPABILITIES.MATCHES_SEND_REQUEST,
+      CAPABILITIES.MATCHES_NAVIGATE_TO_PROFILE,
+    ].forEach((capability) => capabilitySet.add(capability));
+  }
+
+  return capabilitySet;
+};
+
+const noop = () => {};
+
+export const UserContext = createContext({
+  user: defaultSnapshot,
+  capabilities: new Set(),
+  setUser: noop,
+  hasCapability: () => false,
+});
+
+export const UserProvider = ({ children, initialUser, accountStatus }) => {
+  const [snapshot, setSnapshot] = useState(() => {
+    if (initialUser) {
+      return normalizeSnapshotPayload(initialUser);
+    }
+    return defaultSnapshot;
+  });
+
+  useEffect(() => {
+    if (!accountStatus) {
+      return;
+    }
+    setSnapshot((previous) => {
+      if (previous.account === accountStatus) {
+        return previous;
+      }
+      const nextRaw = { ...(previous.raw || previous), account: accountStatus };
+      return normalizeSnapshotPayload(nextRaw);
+    });
+  }, [accountStatus]);
+
+  const updateUser = useCallback((nextUser) => {
+    setSnapshot((previous) => {
+      const nextRaw = { ...(previous.raw || previous), ...(nextUser || {}) };
+      return normalizeSnapshotPayload(nextRaw);
+    });
+  }, []);
+
+  const capabilities = useMemo(() => deriveCapabilities(snapshot), [snapshot]);
+
+  const value = useMemo(
+    () => ({
+      user: snapshot,
+      capabilities,
+      setUser: updateUser,
+      hasCapability: (capability) => capabilities.has(capability),
+    }),
+    [snapshot, capabilities, updateUser]
+  );
+
+  return <UserContext.Provider value={value}>{children}</UserContext.Provider>;
+};
+
+export const useUserContext = () => useContext(UserContext);
+
+export const useUserCapabilities = () => {
+  const { capabilities, hasCapability } = useUserContext();
+  const capabilityList = useMemo(() => Array.from(capabilities), [capabilities]);
+
+  return {
+    capabilities: capabilityList,
+    hasCapability,
+  };
+};
+
+export default UserProvider;


### PR DESCRIPTION
## Summary
- introduce a Home-specific user capability provider and guard wrapper to supply capability checks via context
- refactor the Home tab to consume context-based permissions for filters, expansion, navigation, and match recommendations
- extend the Home tab test to mock the API layer and assert the restricted-state messaging

## Testing
- npm test -- --runTestsByPath src/components/home/Home.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e55e1f1aa0832ebbcd2dad0fea97a6