### PR TITLE
Use capability context and guards in matches tab

### DIFF
--- a/src/components/matches/Guard.js
+++ b/src/components/matches/Guard.js
@@ -1,0 +1,36 @@
+import React from "react";
+import { useUserContext } from "./UserContext";
+
+const Guard = ({ can, fallback = null, children }) => {
+  const { hasCapability } = useUserContext();
+
+  const requirements = React.useMemo(() => {
+    if (!can) {
+      return [];
+    }
+    return Array.isArray(can) ? can.filter(Boolean) : [can];
+  }, [can]);
+
+  const isAllowed = React.useMemo(() => {
+    if (requirements.length === 0) {
+      return true;
+    }
+    return requirements.every((capability) => hasCapability(capability));
+  }, [requirements, hasCapability]);
+
+  if (typeof children === "function") {
+    return <>{children({ isAllowed })}</>;
+  }
+
+  if (isAllowed) {
+    return <>{children}</>;
+  }
+
+  if (typeof fallback === "function") {
+    return <>{fallback({ isAllowed })}</>;
+  }
+
+  return <>{fallback}</>;
+};
+
+export default Guard;

--- a/src/components/matches/UserContext.js
+++ b/src/components/matches/UserContext.js
@@ -1,0 +1,112 @@
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
+import {
+  ACCOUNT_STATUS,
+  BILLING_STATUS,
+  defaultUserSnapshot,
+  normalizeSnapshotPayload,
+} from "../../utils/userDimensions";
+import { CAPABILITIES } from "../../utils/capabilities";
+
+const defaultSnapshot = normalizeSnapshotPayload(defaultUserSnapshot());
+
+const deriveCapabilities = (snapshot) => {
+  const capabilitySet = new Set();
+
+  const isAccountRestricted =
+    snapshot.account === ACCOUNT_STATUS.DEACTIVATED ||
+    snapshot.account === ACCOUNT_STATUS.SUSPENDED;
+  const isBillingRestricted =
+    snapshot.billing === BILLING_STATUS.CANCELLED ||
+    snapshot.billing === BILLING_STATUS.PAST_DUE;
+
+  if (!isAccountRestricted && !isBillingRestricted) {
+    [
+      CAPABILITIES.MATCHES_VIEW_RECOMMENDATIONS,
+      CAPABILITIES.MATCHES_VIEW_DETAILS,
+      CAPABILITIES.MATCHES_VIEW_COMPATIBILITY,
+      CAPABILITIES.MATCHES_SEND_REQUEST,
+      CAPABILITIES.MATCHES_NAVIGATE_TO_PROFILE,
+    ].forEach((capability) => capabilitySet.add(capability));
+  }
+
+  return capabilitySet;
+};
+
+const noop = () => {};
+
+export const UserContext = createContext({
+  user: defaultSnapshot,
+  capabilities: new Set(),
+  setUser: noop,
+  hasCapability: () => false,
+});
+
+export const UserProvider = ({ children, initialUser, accountStatus }) => {
+  const [snapshot, setSnapshot] = useState(() => {
+    const baseSnapshot = initialUser
+      ? normalizeSnapshotPayload(initialUser)
+      : defaultSnapshot;
+
+    if (!accountStatus) {
+      return baseSnapshot;
+    }
+
+    const nextRaw = { ...(baseSnapshot.raw || baseSnapshot), account: accountStatus };
+    return normalizeSnapshotPayload(nextRaw);
+  });
+
+  useEffect(() => {
+    if (!accountStatus) {
+      return;
+    }
+    setSnapshot((previous) => {
+      if ((previous.raw || previous).account === accountStatus) {
+        return previous;
+      }
+      const nextRaw = { ...(previous.raw || previous), account: accountStatus };
+      return normalizeSnapshotPayload(nextRaw);
+    });
+  }, [accountStatus]);
+
+  const updateUser = useCallback((nextUser) => {
+    setSnapshot((previous) => {
+      const nextRaw = { ...(previous.raw || previous), ...(nextUser || {}) };
+      return normalizeSnapshotPayload(nextRaw);
+    });
+  }, []);
+
+  const capabilities = useMemo(() => deriveCapabilities(snapshot), [snapshot]);
+
+  const value = useMemo(
+    () => ({
+      user: snapshot,
+      capabilities,
+      setUser: updateUser,
+      hasCapability: (capability) => capabilities.has(capability),
+    }),
+    [snapshot, capabilities, updateUser]
+  );
+
+  return <UserContext.Provider value={value}>{children}</UserContext.Provider>;
+};
+
+export const useUserContext = () => useContext(UserContext);
+
+export const useUserCapabilities = () => {
+  const { capabilities, hasCapability } = useUserContext();
+  const capabilityList = useMemo(() => Array.from(capabilities), [capabilities]);
+
+  return {
+    capabilities: capabilityList,
+    hasCapability,
+  };
+};
+
+export default UserProvider;


### PR DESCRIPTION
## Summary
- add a matches-specific user capability context and guard component
- refactor match recommendations to derive permissions from context and gate UI with guards
- wrap the matches tab with the new provider so capability checks work consistently

## Testing
- npm test -- MatchRecommendations.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e564b72840832ea0888033a37a1da4