### PR TITLE
Add capability guards to requests tab

### DIFF
--- a/src/components/requests/Guard.js
+++ b/src/components/requests/Guard.js
@@ -1,0 +1,36 @@
+import React from "react";
+import { useUserContext } from "./UserContext";
+
+const Guard = ({ can, fallback = null, children }) => {
+  const { hasCapability } = useUserContext();
+
+  const requirements = React.useMemo(() => {
+    if (!can) {
+      return [];
+    }
+    return Array.isArray(can) ? can.filter(Boolean) : [can];
+  }, [can]);
+
+  const isAllowed = React.useMemo(() => {
+    if (requirements.length === 0) {
+      return true;
+    }
+    return requirements.every((capability) => hasCapability(capability));
+  }, [requirements, hasCapability]);
+
+  if (typeof children === "function") {
+    return <>{children({ isAllowed })}</>;
+  }
+
+  if (isAllowed) {
+    return <>{children}</>;
+  }
+
+  if (typeof fallback === "function") {
+    return <>{fallback({ isAllowed })}</>;
+  }
+
+  return <>{fallback}</>;
+};
+
+export default Guard;

--- a/src/components/requests/UserContext.js
+++ b/src/components/requests/UserContext.js
@@ -1,0 +1,114 @@
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
+import {
+  ACCOUNT_STATUS,
+  BILLING_STATUS,
+  defaultUserSnapshot,
+  normalizeSnapshotPayload,
+} from "../../utils/userDimensions";
+import { CAPABILITIES } from "../../utils/capabilities";
+
+const defaultSnapshot = normalizeSnapshotPayload(defaultUserSnapshot());
+
+const deriveCapabilities = (snapshot) => {
+  const capabilitySet = new Set();
+
+  if (snapshot.account === ACCOUNT_STATUS.DELETED) {
+    return capabilitySet;
+  }
+
+  capabilitySet.add(CAPABILITIES.REQUESTS_VIEW_RECEIVED);
+  capabilitySet.add(CAPABILITIES.REQUESTS_VIEW_SENT);
+  capabilitySet.add(CAPABILITIES.REQUESTS_VIEW_STATUS);
+
+  const isAccountRestricted =
+    snapshot.account === ACCOUNT_STATUS.DEACTIVATED ||
+    snapshot.account === ACCOUNT_STATUS.SUSPENDED;
+  const isBillingRestricted =
+    snapshot.billing === BILLING_STATUS.CANCELLED ||
+    snapshot.billing === BILLING_STATUS.PAST_DUE;
+
+  if (!isAccountRestricted && !isBillingRestricted) {
+    capabilitySet.add(CAPABILITIES.REQUESTS_RESPOND);
+  }
+
+  return capabilitySet;
+};
+
+const noop = () => {};
+
+export const UserContext = createContext({
+  user: defaultSnapshot,
+  capabilities: new Set(),
+  setUser: noop,
+  hasCapability: () => false,
+});
+
+export const UserProvider = ({ children, initialUser, accountStatus }) => {
+  const [snapshot, setSnapshot] = useState(() => {
+    const baseSnapshot = initialUser
+      ? normalizeSnapshotPayload(initialUser)
+      : defaultSnapshot;
+
+    if (!accountStatus) {
+      return baseSnapshot;
+    }
+
+    const nextRaw = { ...(baseSnapshot.raw || baseSnapshot), account: accountStatus };
+    return normalizeSnapshotPayload(nextRaw);
+  });
+
+  useEffect(() => {
+    if (!accountStatus) {
+      return;
+    }
+    setSnapshot((previous) => {
+      if ((previous.raw || previous).account === accountStatus) {
+        return previous;
+      }
+      const nextRaw = { ...(previous.raw || previous), account: accountStatus };
+      return normalizeSnapshotPayload(nextRaw);
+    });
+  }, [accountStatus]);
+
+  const updateUser = useCallback((nextUser) => {
+    setSnapshot((previous) => {
+      const nextRaw = { ...(previous.raw || previous), ...(nextUser || {}) };
+      return normalizeSnapshotPayload(nextRaw);
+    });
+  }, []);
+
+  const capabilities = useMemo(() => deriveCapabilities(snapshot), [snapshot]);
+
+  const value = useMemo(
+    () => ({
+      user: snapshot,
+      capabilities,
+      setUser: updateUser,
+      hasCapability: (capability) => capabilities.has(capability),
+    }),
+    [snapshot, capabilities, updateUser]
+  );
+
+  return <UserContext.Provider value={value}>{children}</UserContext.Provider>;
+};
+
+export const useUserContext = () => useContext(UserContext);
+
+export const useUserCapabilities = () => {
+  const { capabilities, hasCapability } = useUserContext();
+  const capabilityList = useMemo(() => Array.from(capabilities), [capabilities]);
+
+  return {
+    capabilities: capabilityList,
+    hasCapability,
+  };
+};
+
+export default UserProvider;


### PR DESCRIPTION
## Summary
- add a requests-specific user capability provider and guard wrapper
- update the requests tab to respect capability checks for viewing and responding

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e569172c3c832e8bced450af8b399d