### PR TITLE
Add capability context to match insights components

### DIFF
--- a/src/components/matchInsights/Guard.js
+++ b/src/components/matchInsights/Guard.js
@@ -1,0 +1,36 @@
+import React from "react";
+import { useUserContext } from "./UserContext";
+
+const Guard = ({ can, fallback = null, children }) => {
+  const { hasCapability } = useUserContext();
+
+  const requirements = React.useMemo(() => {
+    if (!can) {
+      return [];
+    }
+    return Array.isArray(can) ? can.filter(Boolean) : [can];
+  }, [can]);
+
+  const isAllowed = React.useMemo(() => {
+    if (requirements.length === 0) {
+      return true;
+    }
+    return requirements.every((capability) => hasCapability(capability));
+  }, [requirements, hasCapability]);
+
+  if (typeof children === "function") {
+    return <>{children({ isAllowed })}</>;
+  }
+
+  if (isAllowed) {
+    return <>{children}</>;
+  }
+
+  if (typeof fallback === "function") {
+    return <>{fallback({ isAllowed })}</>;
+  }
+
+  return <>{fallback}</>;
+};
+
+export default Guard;

--- a/src/components/matchInsights/MatchInsights.js
+++ b/src/components/matchInsights/MatchInsights.js
@@ -1,38 +1,66 @@
-import React, { useCallback, useState } from "react";
-import { Box, Stack } from "@mui/material";
+import React from "react";
+import { Alert, Box, Stack } from "@mui/material";
 import CorePreferencesForm from "./CorePreferencesForm";
 import QuestionsComponent from "../questions/Questions";
 import { spacing } from "../../styles";
+import { useAccountLifecycle } from "../../context/AccountLifecycleContext";
+import { CAPABILITIES } from "../../utils/capabilities";
+import Guard from "./Guard";
+import { UserProvider, useUserCapabilities } from "./UserContext";
 
-const defaultStatus = { isLoading: true, isReady: false };
+const QuestionnaireSection = ({ lifecycleLoading }) => {
+  const { hasCapability, getReason } = useUserCapabilities();
+  const canAnswer = hasCapability(CAPABILITIES.INSIGHTS_ANSWER_QUESTIONNAIRE);
 
-function MatchInsights() {
-  const [coreStatus, setCoreStatus] = useState(defaultStatus);
+  const questionnaireLockReason = canAnswer
+    ? undefined
+    : getReason(CAPABILITIES.INSIGHTS_ANSWER_QUESTIONNAIRE) ||
+      "Save your core match preferences to unlock the questionnaire.";
 
-  const handleStatusChange = useCallback((status = defaultStatus) => {
-    setCoreStatus((prev) => {
-      if (
-        prev.isLoading === status.isLoading &&
-        prev.isReady === status.isReady
-      ) {
-        return prev;
-      }
-      return status;
-    });
-  }, []);
+  const questionnaireFallback = (
+    <Alert severity="info" sx={{ borderRadius: 2 }}>
+      {getReason(CAPABILITIES.INSIGHTS_VIEW_QUESTIONNAIRE) ||
+        questionnaireLockReason ||
+        "Match questionnaire is currently unavailable."}
+    </Alert>
+  );
 
-  const isQuestionnaireLocked = coreStatus.isLoading ? true : !coreStatus.isReady;
-  const lockReason = coreStatus.isLoading
-    ? "Loading your preferences..."
-    : "Save your core match preferences to unlock the questionnaire.";
+  const dashboardFallback = (
+    <Box sx={{ px: { xs: 2, md: 6 }, py: { xs: 2, md: 4 } }}>
+      <Alert severity="warning" sx={{ borderRadius: 2 }}>
+        {getReason(CAPABILITIES.INSIGHTS_VIEW_DASHBOARD) ||
+          "Match insights are currently unavailable."}
+      </Alert>
+    </Box>
+  );
 
   return (
-    <Box sx={{ px: { xs: 2, md: 6 }, py: { xs: 2, md: 4 }, pb: 12 }}>
-      <Stack spacing={spacing.pagePadding}>
-        <CorePreferencesForm onStatusChange={handleStatusChange} />
-        <QuestionsComponent isLocked={isQuestionnaireLocked} lockReason={lockReason} />
-      </Stack>
-    </Box>
+    <Guard can={CAPABILITIES.INSIGHTS_VIEW_DASHBOARD} fallback={dashboardFallback}>
+      <Box sx={{ px: { xs: 2, md: 6 }, py: { xs: 2, md: 4 }, pb: 12 }}>
+        <Stack spacing={spacing.pagePadding}>
+          <CorePreferencesForm lifecycleLoading={lifecycleLoading} />
+          <Guard can={CAPABILITIES.INSIGHTS_VIEW_QUESTIONNAIRE} fallback={questionnaireFallback}>
+            <QuestionsComponent
+              isLocked={!canAnswer}
+              lockReason={canAnswer ? undefined : questionnaireLockReason}
+            />
+          </Guard>
+        </Stack>
+      </Box>
+    </Guard>
+  );
+};
+
+function MatchInsights() {
+  const accountLifecycle = useAccountLifecycle();
+
+  return (
+    <UserProvider
+      accountStatus={accountLifecycle?.status}
+      lifecycleLoading={accountLifecycle?.loading}
+    >
+      <QuestionnaireSection lifecycleLoading={accountLifecycle?.loading} />
+    </UserProvider>
   );
 }
 

--- a/src/components/matchInsights/UserContext.js
+++ b/src/components/matchInsights/UserContext.js
@@ -1,0 +1,161 @@
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
+import {
+  defaultUserSnapshot,
+  normalizeSnapshotPayload,
+} from "../../utils/userDimensions";
+import { deriveCapabilities } from "../../utils/capabilities";
+
+const noop = () => {};
+
+const defaultSnapshot = normalizeSnapshotPayload(defaultUserSnapshot());
+const defaultCoreStatus = { loading: false, hasSaved: false };
+
+export const UserContext = createContext({
+  user: defaultSnapshot,
+  setUser: noop,
+  capabilities: new Set(),
+  hasCapability: () => false,
+  getReason: () => undefined,
+  reasons: {},
+  updateCorePreferencesStatus: noop,
+  corePreferencesStatus: defaultCoreStatus,
+  questionnaireLocked: true,
+});
+
+export const UserProvider = ({
+  children,
+  initialUser,
+  accountStatus,
+  lifecycleLoading = false,
+}) => {
+  const [snapshot, setSnapshot] = useState(() => {
+    if (initialUser) {
+      return normalizeSnapshotPayload(initialUser);
+    }
+    return defaultSnapshot;
+  });
+  const [coreStatus, setCoreStatus] = useState(defaultCoreStatus);
+
+  useEffect(() => {
+    if (!accountStatus) {
+      return;
+    }
+    setSnapshot((previous) => {
+      const raw = previous.raw || previous;
+      if (raw.account === accountStatus) {
+        return previous;
+      }
+      const nextRaw = { ...raw, account: accountStatus };
+      return normalizeSnapshotPayload(nextRaw);
+    });
+  }, [accountStatus]);
+
+  const updateUser = useCallback((nextUser) => {
+    setSnapshot((previous) => {
+      const raw = previous.raw || previous;
+      const nextRaw = { ...raw, ...(nextUser || {}) };
+      return normalizeSnapshotPayload(nextRaw);
+    });
+  }, []);
+
+  const updateCorePreferencesStatus = useCallback((status = {}) => {
+    setCoreStatus((previous) => {
+      const nextStatus = {
+        loading:
+          typeof status.loading === "boolean" ? status.loading : previous.loading,
+        hasSaved:
+          typeof status.hasSaved === "boolean" ? status.hasSaved : previous.hasSaved,
+      };
+      if (
+        nextStatus.loading === previous.loading &&
+        nextStatus.hasSaved === previous.hasSaved
+      ) {
+        return previous;
+      }
+      return nextStatus;
+    });
+  }, []);
+
+  const effectiveLoading = Boolean(lifecycleLoading) || Boolean(coreStatus.loading);
+  const questionnaireLocked = effectiveLoading || !coreStatus.hasSaved;
+
+  const capabilitySnapshot = useMemo(
+    () =>
+      deriveCapabilities({
+        user: snapshot,
+        hasSavedCorePreferences: coreStatus.hasSaved,
+        questionnaireLocked,
+      }),
+    [snapshot, coreStatus.hasSaved, questionnaireLocked]
+  );
+
+  const allowed = capabilitySnapshot.allowed || {};
+  const reasons = capabilitySnapshot.reasons || {};
+
+  const capabilitySet = useMemo(() => {
+    const set = new Set();
+    Object.entries(allowed).forEach(([key, value]) => {
+      if (value) {
+        set.add(key);
+      }
+    });
+    return set;
+  }, [allowed]);
+
+  const hasCapability = useCallback((capability) => Boolean(allowed[capability]), [
+    allowed,
+  ]);
+  const getReason = useCallback((capability) => reasons[capability], [reasons]);
+
+  const value = useMemo(
+    () => ({
+      user: snapshot,
+      setUser: updateUser,
+      capabilities: capabilitySet,
+      hasCapability,
+      getReason,
+      reasons,
+      updateCorePreferencesStatus,
+      corePreferencesStatus: {
+        loading: effectiveLoading,
+        hasSaved: coreStatus.hasSaved,
+      },
+      questionnaireLocked,
+    }),
+    [
+      snapshot,
+      updateUser,
+      capabilitySet,
+      hasCapability,
+      getReason,
+      reasons,
+      updateCorePreferencesStatus,
+      effectiveLoading,
+      coreStatus.hasSaved,
+      questionnaireLocked,
+    ]
+  );
+
+  return <UserContext.Provider value={value}>{children}</UserContext.Provider>;
+};
+
+export const useUserContext = () => useContext(UserContext);
+
+export const useUserCapabilities = () => {
+  const { capabilities, hasCapability, getReason } = useUserContext();
+  const capabilityList = useMemo(() => Array.from(capabilities), [capabilities]);
+  return {
+    capabilities: capabilityList,
+    hasCapability,
+    getReason,
+  };
+};
+
+export default UserProvider;


### PR DESCRIPTION
## Summary
- add a match insights user provider that derives capability state from the shared capability matrix
- update the match insights view to wrap content in the provider and guard questionnaire visibility by capability
- refactor the core preferences form to respect capability permissions and feed status back into the provider

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e5797f5d80832e91a7a0a287bde0df