### PR TITLE
Fix missing closing Guard tag in questionnaire component

### DIFF
--- a/src/components/questions/Questions.js
+++ b/src/components/questions/Questions.js
@@ -384,10 +384,10 @@ function QuestionsComponent({
           severity={snackbar.severity}
           sx={{ width: "100%" }}
         >
-          {snackbar.message}
-        </Alert>
-      </Snackbar>
-    </>
+        {snackbar.message}
+      </Alert>
+    </Snackbar>
+    </Guard>
   );
 }
 


### PR DESCRIPTION
## Summary
- close the Guard component in Questions.js to fix JSX syntax error

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e582f81158832ea133f3341816e129