### PR TITLE
Adjust discovery behavior for deactivated accounts

### DIFF
--- a/src/components/home/Home.js
+++ b/src/components/home/Home.js
@@ -71,10 +71,12 @@ function HomeContent({ accountLifecycle }) {
   const { isDeactivated = false, loading: lifecycleLoading = false } =
     accountLifecycle || {};
   const discoveryBlockedByLifecycle = !lifecycleLoading && isDeactivated;
-  const canViewHome = hasCapability(CAPABILITIES.DISCOVERY_VIEW_HOME);
-  const canViewActiveUsers = hasCapability(
-    CAPABILITIES.DISCOVERY_VIEW_ACTIVE_USERS
-  );
+  const canViewHome =
+    discoveryBlockedByLifecycle ||
+    hasCapability(CAPABILITIES.DISCOVERY_VIEW_HOME);
+  const canViewActiveUsers =
+    discoveryBlockedByLifecycle ||
+    hasCapability(CAPABILITIES.DISCOVERY_VIEW_ACTIVE_USERS);
   const canUseFilters = hasCapability(CAPABILITIES.DISCOVERY_USE_FILTERS);
   const canToggleFilterPanel = hasCapability(
     CAPABILITIES.DISCOVERY_TOGGLE_FILTER_PANEL
@@ -531,17 +533,18 @@ function HomeContent({ accountLifecycle }) {
     );
   };
 
+  const activeUsersGuardRequirement = discoveryBlockedByLifecycle
+    ? null
+    : CAPABILITIES.DISCOVERY_VIEW_ACTIVE_USERS;
+
   return (
     <Container sx={{ p: spacing.pagePadding }}>
       <Stack spacing={spacing.section}>
-        {discoveryBlockedByLifecycle ? (
-          <Alert severity="warning">{ACCOUNT_DEACTIVATED_MESSAGE}</Alert>
-        ) : null}
         <Guard can={CAPABILITIES.MATCHES_VIEW_RECOMMENDATIONS}>
           <MatchRecommendations limit={12} />
         </Guard>
         <Guard
-          can={CAPABILITIES.DISCOVERY_VIEW_ACTIVE_USERS}
+          can={activeUsersGuardRequirement}
           fallback={
             <Alert severity="info">
               {t("home.messages.activeUsersUnavailable", {

--- a/src/components/home/Home.test.js
+++ b/src/components/home/Home.test.js
@@ -23,7 +23,7 @@ jest.mock("../matches/MatchRecommendations", () => () => (
 ));
 
 describe("Home discovery gating", () => {
-  it("hides active users and shows the deactivation banner when discovery is disabled", async () => {
+  it("keeps active users visible without showing the deactivation banner", async () => {
     const contextValue = {
       status: "deactivated",
       loading: false,
@@ -49,9 +49,11 @@ describe("Home discovery gating", () => {
     );
 
     expect(
-      await screen.findByText(
-        "Access to the discovery feed is unavailable for your account."
-      )
+      await screen.findByText("home.headers.activeUsers")
     ).toBeInTheDocument();
+
+    expect(
+      screen.queryByText(ACCOUNT_DEACTIVATED_MESSAGE)
+    ).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- allow the home feed and active users list to render when the account lifecycle is deactivated
- limit capability gating for the active users card so it still shows users while requests remain disabled
- update the home gating test to reflect the new behavior without the global deactivation banner

## Testing
- CI=true npm test -- --runTestsByPath src/components/home/Home.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e58e0136fc832eae7351d915bc94a0