### PR TITLE
Allow deactivated users to view profiles

### DIFF
--- a/src/components/home/Home.js
+++ b/src/components/home/Home.js
@@ -84,9 +84,9 @@ function HomeContent({ accountLifecycle }) {
   const canExpandUserPreview = hasCapability(
     CAPABILITIES.DISCOVERY_EXPAND_USER_PREVIEW
   );
-  const canNavigateToProfile = hasCapability(
-    CAPABILITIES.DISCOVERY_NAVIGATE_TO_PROFILE
-  );
+  const canNavigateToProfile =
+    discoveryBlockedByLifecycle ||
+    hasCapability(CAPABILITIES.DISCOVERY_NAVIGATE_TO_PROFILE);
   const canComposeRequest = hasCapability(
     CAPABILITIES.DISCOVERY_COMPOSE_REQUEST
   );


### PR DESCRIPTION
## Summary
- allow deactivated accounts that are blocked from discovery to continue navigating to active user profiles

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e592d71d5c832e9e907b21384d29ba