### PR TITLE
Gracefully handle request status fetch errors on profile load

### DIFF
--- a/src/components/profile/Profile.js
+++ b/src/components/profile/Profile.js
@@ -132,7 +132,7 @@ function ProfileContent() {
       setFeedback(null);
       try {
         const token = localStorage.getItem("token");
-        const [profileResponse, requestResponse] = await Promise.all([
+        const [profileResult, requestResult] = await Promise.allSettled([
           api.get(`/user/profile/${userId}`, {
             headers: { Authorization: `${token}` },
           }),
@@ -145,9 +145,17 @@ function ProfileContent() {
           return;
         }
 
-        const formatted = formatProfileData(profileResponse.data);
+        if (profileResult.status !== "fulfilled") {
+          throw profileResult.reason;
+        }
+
+        const formatted = formatProfileData(profileResult.value.data);
         setProfile(formatted);
-        setRequestStatus(Boolean(requestResponse.data.requestStatus));
+        if (requestResult.status === "fulfilled") {
+          setRequestStatus(Boolean(requestResult.value.data.requestStatus));
+        } else {
+          setRequestStatus(false);
+        }
       } catch (error) {
         if (!active) {
           return;


### PR DESCRIPTION
## Summary
- prevent request status API failures from blocking profile loading by switching to `Promise.allSettled`
- default the request status to false when the endpoint is unavailable so the rest of the profile renders

## Testing
- CI=true npm test -- --watchAll=false

------
https://chatgpt.com/codex/tasks/task_e_68e59536ce94832ea74ac462aefe4bad