### PR TITLE
Stop fetching discovery data for deactivated accounts

### DIFF
--- a/src/components/home/Home.js
+++ b/src/components/home/Home.js
@@ -110,7 +110,7 @@ function HomeContent({ accountLifecycle }) {
 
   const fetchActiveUsers = useCallback(
     async (params = {}) => {
-      if (!canViewActiveUsers) {
+      if (discoveryBlockedByLifecycle || !canViewActiveUsers) {
         if (activeUsersAbortRef.current) {
           activeUsersAbortRef.current.abort();
           activeUsersAbortRef.current = null;
@@ -169,7 +169,11 @@ function HomeContent({ accountLifecycle }) {
         setLoadingUsers(false);
       }
     },
-    [canViewActiveUsers, getUserIdentifier]
+    [
+      canViewActiveUsers,
+      discoveryBlockedByLifecycle,
+      getUserIdentifier,
+    ]
   );
 
   const buildFilterParams = useCallback(() => {
@@ -240,7 +244,7 @@ function HomeContent({ accountLifecycle }) {
 
   // Toggle and fetch detailed profile data
   const handleToggleExpand = async (rawUserId) => {
-    if (!canExpandUserPreview) {
+    if (!canExpandUserPreview || discoveryBlockedByLifecycle) {
       return;
     }
     const userId = Number(rawUserId);

--- a/src/components/matches/MatchRecommendations.js
+++ b/src/components/matches/MatchRecommendations.js
@@ -326,10 +326,14 @@ const MatchRecommendationsContent = ({ limit = 10, accountLifecycle }) => {
       return () => {};
     }
 
-    if (!canViewRecommendations) {
+    if (!canViewRecommendations || requestsBlockedByLifecycle) {
       setStatus({ loading: false, errorKey: "" });
       setMatches([]);
       setExpandedMatchId(null);
+      setProfileDetails({});
+      setRequestMessages({});
+      setRequestErrors({});
+      setFeedback({});
       if (detailAbortRef.current) {
         detailAbortRef.current.abort();
         detailAbortRef.current = null;
@@ -379,6 +383,7 @@ const MatchRecommendationsContent = ({ limit = 10, accountLifecycle }) => {
     limit,
     canViewRecommendations,
     lifecycleLoading,
+    requestsBlockedByLifecycle,
     detailAbortRef,
   ]);
 
@@ -390,7 +395,7 @@ const MatchRecommendationsContent = ({ limit = 10, accountLifecycle }) => {
   }, [matches]);
 
   const handleToggleExpand = async (matchKey, rawUserId) => {
-    if (!canViewDetails) {
+    if (!canViewDetails || requestsBlockedByLifecycle) {
       return;
     }
 


### PR DESCRIPTION
## Summary
- prevent the home discovery view from requesting active users or profile details when the account lifecycle is deactivated
- halt match recommendation requests and detail lookups when lifecycle deactivates the user

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e59e8b1d50832e9e898be08dc0684b